### PR TITLE
fix typo

### DIFF
--- a/issues/2020-10.md
+++ b/issues/2020-10.md
@@ -229,5 +229,5 @@ e.increment();  // logs 2
 
 Webpack을 번들러로 사용하고 있다면 [comlink-loader](https://github.com/GoogleChromeLabs/comlink-loader)를 같이 사용해, 코드의 일부 수정(또는 없이)을 통해 사용되는 모듈들을 WebWorkers 스레드에서 실행될 수 있도록 만들 수도 있다.
 
-## [git CLI](https://cli.github.com/)
+## [github CLI](https://cli.github.com/)
 GitHub의 공식 CLI 도구로 Beta 기간을 끝내고, 얼마 전 1.0 버전을 선보였다. 터미널 상에서 GitHub PR을 만들거나 관리도 할 수 있다.


### PR DESCRIPTION
news 잘보고 있습니다.

`git cli`보다는 `github cli`가 맞을것 같습니다.