### PR TITLE
[modify] 2021-08 image src

### DIFF
--- a/issues/2021-08.md
+++ b/issues/2021-08.md
@@ -40,7 +40,7 @@ Yarn 1 &rarr; 2로의 마이그레이션 과정에서의 불편함을 제거해,
 
 ## [A Visual Guide to React Rendering - It Always Re-renders](https://alexsidorenko.com/blog/react-render-always-rerenders/)
 
-<img src="https://alexsidorenko.com/6a963b5633b0c2026c6115bd5058703f/parent-rerender.gif" width=500>
+<img src="https://user-images.githubusercontent.com/69495129/149443831-d0d89632-d994-42b0-b5dc-5ea47415646c.gif" width=500>
 
 React 애플리케이션 구조와 상탯값 변경에 따라 컴포넌트별 재 렌더링이 발생하는 과정을 시각적 예제를 통해 보여주고, React.memo를 통해 불필요한 재 렌더링을 방지할 수 있는지 설명한다.
 
@@ -63,7 +63,7 @@ Evan You는 온라인 세션을 통해 프로젝트의 자세한 배경(기술�
 
 ## [RenderingNG](https://developer.chrome.com/blog/renderingng/)
 
-<img src="https://developer-chrome-com.imgix.net/image/ZDZVuXt6QqfXtxkpXcPGfnygYjd2/m1d1iB6Ts2HqWRAx8cX5.jpg?w=350"> 
+<img src="https://user-images.githubusercontent.com/69495129/149443946-ec4a40a3-b410-4c75-baba-b90ba5ae237d.png" width="350" height="350"> 
 
 Chrome 개발팀은 지난 8년여의 작업을 통해 Chromium의 Blink 렌더링 엔진을 새롭게 재설계한 아키텍처인 [RenderingNG](https://developer.chrome.com/blog/renderingng/)(Next Generation)를 공개했다. 
 
@@ -143,7 +143,7 @@ CSSWG은 2021/7/7, 관련 제안에 대해 Public Working Draft 발행에 동의
 
 ## [Windows 11 in React](https://github.com/blueedgetechno/windows11)
 
-<img src=https://github.com/blueedgetechno/windows11/raw/master/public/img/home.png width=500>
+<img src=https://github.com/blueedgetechno/windows11/raw/master/public/img/home.jpg width=500>
 
 웹 표준 기술(React)을 사용해, 웹에서 Windows 11 데스크톱 버전을 경험해 볼 수 있도록 복제한 프로젝트다.
 
@@ -154,7 +154,7 @@ https://win11.blueedge.me/
 
 ## [Abracadabra](https://github.com/nicoespeon/abracadabra)
 
-<img src="https://github.com/nicoespeon/abracadabra/raw/master/docs/logo/abracadabra-logo.png?raw=true" width=500>
+<img src="https://github.com/nicoespeon/abracadabra/blob/main/docs/logo/abracadabra-logo.png?raw=true" width=500>
 
 VS Code에서 제공하는 [기본적 리팩토링](https://code.visualstudio.com/docs/editor/refactoring)에 더해 리팩토링을 빠르고 안전하게 수행할 수 있는 추가적 기능을 제공하는 플러그인이다.
 
@@ -164,7 +164,7 @@ VS Code에서 제공하는 [기본적 리팩토링](https://code.visualstudio.co
 
 ## [slinky](https://slinky.dev/)
 
-<img src=https://github.com/shadaj/slinky/raw/master/logo.png width=200>
+<img src=https://github.com/shadaj/slinky/blob/main/logo.png width=200>
 
 Slinky는 Scala로 React 애플리케이션을 작성할 수 있는 프레임워크다.
 


### PR DESCRIPTION
항상 올려주시는 자료 잘 구독하고 있습니다. 감사합니다.


5가지 이미지가 깨지는 현상이 발생하였습니다.
적절한 이미지 혹은 올바른 경로로 이미지 소스를 수정하였습니다.

- A Visual Guide to React Rendering - It Always Re-renders
  - 실제 사이트에서 gif 제공을 중단하고 mp4 를 제공하여서 기존 gif 경로가 올바르지 않았습니다.
- RenderingNG
  - 이미지 경로 수정하였습니다.
- Windows 11 in React
  - 이미지가 jpg 에서 png 로 수정되었습니다.
- Abracadabra
  - 이미지 경로 수정
- slinky
  - 이미지 경로 수정

감사합니다.