### PR TITLE
typo: fix the link of closure trap post

### DIFF
--- a/issues/2022-07.md
+++ b/issues/2022-07.md
@@ -86,7 +86,7 @@ HTML / CSS / Web Inspector / Web API / JavaScript 그리고 WebAssembly / Securi
 보안 7개월, 백엔드 1년 7개월 경험이 있는 경력 3년 차 개발자의 프론트엔드 개발 전환기이다.
 처음부터 어떻게 학습했고, 어떤 강좌를 통해 학습을 했는지 기술하고 있다. 초보 개발자나 프론트엔드 개발을 처음 시작하시는 분이라면 참고해 보면 좋을 것 같다.
 
-## [Understanding the Closure Trap of React Hooks](https://jrsinclair.com/articles/2022/javascript-function-composition-whats-the-big-deal/)
+## [Understanding the Closure Trap of React Hooks](https://betterprogramming.pub/understanding-the-closure-trap-of-react-hooks-6c560c408cde)
 <img src="https://miro.medium.com/max/1400/1*QIRyn9NniP8LJQNpt8tuMA.png" width="500">
 
 React 16.8 버전부터 Hook이 나온 이후로 이제는 보편적으로 Hook을 사용한다.


### PR DESCRIPTION
"Understanding the Closure Trap of React Hooks" 포스트 링크가 잘못된 것 같아 수정하였습니다.