### PR TITLE
fix: 2022-08 오타 수정

### DIFF
--- a/issues/2022-08.md
+++ b/issues/2022-08.md
@@ -55,7 +55,7 @@ Next.js를 개발(또한 [socket.io](https://socket.io/), [Mongoose](https://mon
 
 ## [Front-end Web Performance: The Essentials](https://medium.com/@matthew.costello/frontend-web-performance-the-essentials-0-61fea500b180)
 
-시리즈로 구성된(아직 완성되지 않은) 글을 통해 저자는 웹 성능을 위해 이해야 하는 본질적 요소들을 하나씩 설명한다.
+시리즈로 구성된(아직 완성되지 않은) 글을 통해 저자는 웹 성능을 위해 이해해야 하는 본질적 요소들을 하나씩 설명한다.
 
 첫 번째 시리즈 글에선 브라우저의 렌더링 사이클과 하드웨어 가속, 합성 레이어 등에 대한 전반적인 브라우저의 렌더링 과정을 다루며, 두 번째 글에선 이벤트 루프, 비동기 스케줄링 등을 통해 브라우저의 동작을 블록 하지 않는 것에 대한 설명을 이어 간다.
 


### PR DESCRIPTION
안녕하세요. 
이번 2022년 8월 아티클의 "Front-end Web Performance: The Essentials" 단락의 내용 중 오타가 있어 수정하였습니다.