### PR TITLE
비정상 링크 수정

### DIFF
--- a/issues/2022-11.md
+++ b/issues/2022-11.md
@@ -120,7 +120,7 @@ React RFC로 올라와서 큰 반응을 얻고 있다. React 컴포넌트에서 
 
 JavaScript 씬에서 유명한 테크니션인 [Axel Rauschmayer](http://dr-axel.de/?)의 저서로 Node.js가 어떻게 동작하는지와 생태계 전반 및 npm 패키지를 자세히 다루고 있다. 온라인상의 HTML 버전은 무료로 전체 내용이 제공된다.
 
-## [A World-Class Code Playground with Sandpack](https://dev.to/srmagura/why-were-breaking-up-wiht-css-in-js-4g9b)
+## [A World-Class Code Playground with Sandpack](https://www.joshwcomeau.com/react/next-level-playground/)
 
 <img src="https://user-images.githubusercontent.com/4838076/163777661-a44ec0a9-ee7c-483a-bdbb-7898ba665f68.gif" width="500">
 


### PR DESCRIPTION
[A World-Class Code Playground with Sandpack](https://www.joshwcomeau.com/react/next-level-playground/)의 링크가 [Why We're Breaking Up with CSS-in-JS](https://dev.to/srmagura/why-were-breaking-up-wiht-css-in-js-4g9b)의 링크로 되어 있어서 수정해보았습니다