### PR TITLE
fix: 2022-11 링크 수정

### DIFF
--- a/issues/2022-11.md
+++ b/issues/2022-11.md
@@ -41,7 +41,7 @@ Webpack의 창시자인 [Tobias Koppers](https://twitter.com/wsokra)의 주도�
 
 지난 10월 31일, Shopify는 Remix 프레임워크와 개발진에 대한 인수 소식을 밝혔다.
 
-Shopify는 그간 자사의 스토어 기반 서비스 제공을 위해 React 기반 프레임워크인 [Hydrogen](https://github.com/Shopify/hydrogen)과 이를 위한 서버리스 플랫폼인 [Oxygen](https://papago.naver.net/apis/site/proxy?url=https%3A%2F%2Fshopify.engineering%2Fhow-we-built-oxygen)을 개발하고 공개했었고, 지난 [Remix Conf](https://www.youtube.com/watch?v=zCSXGY6fhIE)에서 [Hydrogen UI](https://github.com/Shopify/hydrogen-ui)를 발표하며 Hydrogen 레이어가 다른 프레임워크에서도 사용될 수 있다는 것을 보여줬었다.
+Shopify는 그간 자사의 스토어 기반 서비스 제공을 위해 React 기반 프레임워크인 [Hydrogen](https://github.com/Shopify/hydrogen)과 이를 위한 서버리스 플랫폼인 [Oxygen](https://shopify.engineering/how-we-built-oxygen)을 개발하고 공개했었고, 지난 [Remix Conf](https://www.youtube.com/watch?v=zCSXGY6fhIE)에서 [Hydrogen UI](https://github.com/Shopify/hydrogen-ui)를 발표하며 Hydrogen 레이어가 다른 프레임워크에서도 사용될 수 있다는 것을 보여줬었다.
 
 이후 몇 달간 Remix 개발팀과의 아이디어를 교류하던 끝에 커머스 개발자가 빠르게 스토어를 쉽게 구축할 수 있도록 지원하는 데 필요한 개념은 Remix에 코드화된 베스트 프랙티스와 동일하며 이를 위해 힘을 합치는 것에 대한 공감대가 형성되었다고 한다.
 
@@ -159,9 +159,9 @@ Airbnb에서 개발한 D3.js기반 React용 시각화 라이브러리
 <Img src="https://miro.medium.com/max/1400/1*RGQCNNO-SSQ8PHnIZ4BVTQ.jpeg" width="500px"> 
 
 
-[FE News 2022년 6월 호](https://github.com/naver/fe-news/blob/34ce79a91ca2eef771ff9b5c7a18f994f501bc3a/issues/2022-06.md#announcement-passing-the-torch)에서 Lerna의 오너십이 [nrwl](https://nrwl.io/)로 이전되었다고 소개되었다. 
+[FE News 2022년 6월 호](https://github.com/naver/fe-news/blob/34ce79a91ca2eef771ff9b5c7a18f994f501bc3a/issues/2022-06.md#announcement-passing-the-torch)에서 Lerna의 오너십이 [Nrwl](https://nrwl.io/)로 이전되었다고 소개되었다. 
 
-오너십을 이전한 뒤 nrwl의 개발진은 Lerna를 5버전으로 올리고 Lerna와 Nx의 통합을 진행하였다.
+오너십을 이전한 뒤 Nrwl의 개발진은 Lerna를 5버전으로 올리고 Lerna와 Nx의 통합을 진행하였다.
 
 그리고 빠르게 Nx가 기본으로 사용되는 V6을 출시하였다.
 V6은 이전의 Lerna(V4 이하)에서 쉽게 버전 업그레이드가 가능하다.([업그레이드 Youtube](https://www.youtube.com/shorts/kOD7880DNEE))


### PR DESCRIPTION

Oxygen 링크 주소에 파파고 주소 포함되어 있어 접속이 안되기에 수정했습니다.

추가로, 수정 내용은 아닙니다만
[Shapeless](https://github.com/naver/fe-news/blame/master/issues/2022-11.md#L180) 주소가 접속이 안되네요.
이전에는 올바른 주소였는데 사이트에서 삭제하거나 옮긴것같습니다. 😿 

