### PR TITLE
fix: 비정상 링크 수정

### DIFF
--- a/issues/2022-09.md
+++ b/issues/2022-09.md
@@ -19,7 +19,7 @@ V8 JavaScript 엔진의 동작을 상황(기본, 오류, 스택오버플로, 비
 TypeScript의 개념을 애니메이션 이미지를 이용하여 쉽게 설명한 글이다.  
 TypeScript의 다양한 타입들의 실행 흐름도 함께 보여주어 빠르게 이해하기 좋다.  
 위의 주제 외에도 아래와 같은 글들이 있고, 계속 업데이트 되고 있다.
-* [Using TypeScript Mapped Types Like a Pro](https://javascript.plainenglish.io/use-typescript-conditional-types-like-a-pro-7baea0ad05c5)
+* [Using TypeScript Mapped Types Like a Pro](https://medium.com/javascript-in-plain-english/using-typescript-mapped-types-like-a-pro-be10aef5511a)
 * [Using TypeScript Conditional Types Like a Pro](https://javascript.plainenglish.io/use-typescript-conditional-types-like-a-pro-7baea0ad05c5)
 * [Using TypeScript infer Like a Pro](https://levelup.gitconnected.com/using-typescript-infer-like-a-pro-f30ab8ab41c7)
 * [Using TypeScript Template Literal Types Like a Pro](https://medium.com/javascript-in-plain-english/how-to-use-typescript-template-literal-types-like-a-pro-2e02a7db0bac)

--- a/issues/2022-10.md
+++ b/issues/2022-10.md
@@ -98,7 +98,7 @@ React를 처음부터 개발하는 과정을 다룬다.
 
 10개의 타입스크립트 챌린지 문제와 해설을 통해서 타입스크립트 타입 레벨 프로그래밍을 기초부터 익힐 수 있다
 
-영상을 통해 타입 레벨 프로그래밍에 익숙해졌다면 [type-challenges](../issues/2021-12.md#typechallengehttpsgithubcomtype-challengestype-challenges)를 다시 한번 도전해 보는 것도 좋을 것이다
+영상을 통해 타입 레벨 프로그래밍에 익숙해졌다면 [type-challenges](../issues/2021-12.md#typechallenge)를 다시 한번 도전해 보는 것도 좋을 것이다
 
 ## [Web Scraping Google With Node JS](https://serpdog.io/blog/web-scraping-google-with-node-js)
 


### PR DESCRIPTION
## 수정 내용

### 2022-10
- **type-challenges** 링크가 2021-12 문서의 타입 챌린지 링크로 연결하도록 수정했습니다.

### 2022-09 
- **What Are K, T, and V in TypeScript Generics?** 항목의 문서 중 중복 링크가 있어서 수정했습니다.