### PR TITLE
modern-errors example 수정

### DIFF
--- a/issues/2023-01.md
+++ b/issues/2023-01.md
@@ -102,6 +102,7 @@ modern-errors는 오류들을 쉽고 안정적이게, 그리고 일관되게 처
 ```js
 // 1) 오류를 핸들링할 클래스를 생성한다.
 import ModernError from 'modern-errors';
+const BaseError = ModernError.subclass('BaseError');
 export const InputError = BaseError.subclass('InputError', {
   plugins: [modernErrorsSerialize],  // 제공되는 플러그인을 사용할 수도 있다.
 });


### PR DESCRIPTION
`BaseError` 선언하고 할당하는 부분이 예제 코드에 있어야 할거 같은데 
없어서 추가하고 PR드립니다.