### PR TITLE
깨진 URL 변경

### DIFF
--- a/issues/2023-04.md
+++ b/issues/2023-04.md
@@ -80,7 +80,7 @@ Vercel이 모노레포 툴 Turborepo를 기존의 Go 언어에서 Rust로 옮기
 
 ## [How to start a React Project in 2023](https://www.robinwieruch.de/react-starter/)
 
-FE-news 구독자분들이라면 지난 3월 [Replace Create React App recommendation with Vite](https://oss.navercorp.com/fe-news/fe-news/blob/dev/issues/2023-03.md#replace-create-react-app-recommendation-with-vite)에서 공식 문서의 추천 도구로 CRA 대신 Vite로 대체하자는 PR과 그에 대한 Dan Abramov의 답변을 소개한 사실을 알고 있을 것이라고 생각한다.
+FE-news 구독자분들이라면 지난 3월 [Replace Create React App recommendation with Vite](https://github.com/naver/fe-news/blob/master/issues/2023-03.md#replace-create-react-app-recommendation-with-vite)에서 공식 문서의 추천 도구로 CRA 대신 Vite로 대체하자는 PR과 그에 대한 Dan Abramov의 답변을 소개한 사실을 알고 있을 것이라고 생각한다.
 
 지금 소개하는 이 글은 위의 답변 이후 작성된 react.dev의 [Start a new React Project](https://react.dev/learn/start-a-new-react-project)를 보고 작성되었다.
 [Start a new React Project](https://react.dev/learn/start-a-new-react-project)에서는 Next.js, Remix, Gatsby, Expo를 추천하는데, 작가는 커뮤니티들에서 이 추천 목록이 완벽하게 받아들여지지 않는 것 같다고 이야기하면서, 초보자들에게 좀 더 다양한 선택지를 제공하기 위해 Vite, Next.js, Astro를 추천한다.


### PR DESCRIPTION
oss.navercorp는 네이버 외부에서 접근할 수 없는 것 같아 github 링크로 대체합니다.
FE 뉴스 잘 보고있어요!! 감사합니다.