### PR TITLE
fix: fix typo CSS Modules

### DIFF
--- a/issues/2023-09.md
+++ b/issues/2023-09.md
@@ -20,7 +20,7 @@ React에서 메모이제이션이 성능 개선의 만능 해결책일까?
 
 CSS Frameworks 부문에서는 [Tailwind CSS](https://tailwindcss.com/)가 전년도에 이어 계속해서 사용량이 우상향 하며 50%를 기록했고 가장 높은 긍정적인 경험을 나타내었다. 하지만 관심도와 만족도 부분에서는 [Open Props](https://open-props.style/)가 Tailwind CSS를 앞지르는 모습을 보였다.
 
-CSS-in-JS 부문에서는 CSS Moudules가 가장 큰 만족도를 보였고 Styled Components가 그 뒤를 이었다.
+CSS-in-JS 부문에서는 CSS Modules가 가장 큰 만족도를 보였고 Styled Components가 그 뒤를 이었다.
 
 CSS Frameworks와 CSS-in-JS 사용자의 행복도를 비교하면 각각 35.1%, 20.3%로 CSS Frameworks 사용자의 행복도가 좀 더 높았다.
 
@@ -52,7 +52,8 @@ htmx는 어쩌면 우리가 일반적으로 알고 있는 개발 방식에 새�
   hx-post="/some-api"
   hx-trigger="click"
   hx-target="#parent-div"
-  hx-swap="outerHTML">
+  hx-swap="outerHTML"
+>
   Click Me!
 </button>
 ```


### PR DESCRIPTION
CSS Modules가 CSS Moudules로 오타가 났어서 수정 PR 날립니다. 
항상 잘 읽고 있습니다 감사합니다!