### PR TITLE
fix: CSS Scroll Snap example image

### DIFF
--- a/issues/2020-02.md
+++ b/issues/2020-02.md
@@ -52,7 +52,7 @@ Web Almanac은 [HTTP Archive](https://httparchive.org/)를 통해 수집된 다�
 
 > CSS Scroll Snap는 CSS 만으로 다음과 같은 캐로셀 인터렉션을 쉽게 구현할 수 있다.
 
-<img src=https://i2.wp.com/css-tricks.com/wp-content/uploads/2018/07/scroll-snap-demo.gif width=300>
+<img src="https://i.imgur.com/7KtxUjL.gif" width=300>
 
 ## [Learning Modern JavaScript with Tetris](https://medium.com/@michael.karen/learning-modern-javascript-with-tetris-92d532bcd057)
 


### PR DESCRIPTION
## Description
예제 이미지 중 보이지 않는 이미지가 있어 imgur에 호스팅한 링크로 대체했습니다.

## Before
<img width="698" alt="image" src="https://github.com/naver/fe-news/assets/42014299/2979e43a-4e71-4529-b793-0fd1365561df">

## After
<img width="723" alt="image" src="https://github.com/naver/fe-news/assets/42014299/014174e1-8071-4c44-ae5b-a4ab32ee342b">
