### PR TITLE
누락된 링크 추가

### DIFF
--- a/issues/2024-03.md
+++ b/issues/2024-03.md
@@ -109,7 +109,7 @@ React 개발자 중 상위 1%가 GitHub star를 누른 저장소는 무엇일까
 [CSS Custom Highlight API](https://drafts.csswg.org/css-highlight-api-1/)와 토큰화를
 위한 [Prism.js](https://prismjs.com/)를 사용하면 스타일링을 위해 DOM 트리를 여러 개의 `<span>`으로 뒤섞는 단계를 건너뛸 수 있다.
 
-## [The New CSS Math: pow(), sqrt(), and exponential friends]()
+## [The New CSS Math: pow(), sqrt(), and exponential friends](https://danielcwilson.com/posts/mathematicss-powers/)
 
 CSS는 [calc()](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)과 같은 기존 함수들을 보완하기 위해 많은 새로운 Math 함수들이 추가되었다. 이 함수들은 모두 궁극적으로 숫자 값을 나타내지만, 작동 방식의 뉘앙스는 명확하지 않다.
 


### PR DESCRIPTION
"The New CSS Math: pow(), sqrt(), and exponential friends" 헤딩에 링크(https://danielcwilson.com/posts/mathematicss-powers/)가 누락되어 있어서 추가합니다.