### PR TITLE
fix: 오타 수정

### DIFF
--- a/issues/2024-07.md
+++ b/issues/2024-07.md
@@ -12,7 +12,7 @@ Web Engines Hackfest는 2009년 WebkitGTK+ Hackfest라는 이름으로 처음 �
 올해는 총 8개의 세션이 진행되었고, 흥미로운 몇몇 세션들은 다음과 같다.
 
 - [The Future of Source Maps](https://youtu.be/dre3gPQlYvg?list=PL4sEzdAGvRgBVK-g6z4-YGt8uv3Dni6ag) ([발표자료](https://webengineshackfest.org/2024/slides/the_future_of_source_maps_by_jonathan_kuperman.pdf)) - Jonathan Kuperman
-  - 소스 맵은 2009년 처음 개발된 후로 사양은 크게 변하지 않았다. 이로 인해 기능 개발이 정체되왔으나, 2023년에 현대화를 위한 그룹이 구성되어 공식 TC39 테스크 그룹으로 승격되었다. 이 세션은 사양에 포함될 흥미로운 신규 기능들을 소개한다.
+  - 소스 맵은 2009년 처음 개발된 후로 사양은 크게 변하지 않았다. 이로 인해 기능 개발이 정체되어 왔으나, 2023년에 현대화를 위한 그룹이 구성되어 공식 TC39 테스크 그룹으로 승격되었다. 이 세션은 사양에 포함될 흥미로운 신규 기능들을 소개한다.
 
 - [Firefox Wayland post mortem](https://youtu.be/3iilx5DBgJM?list=PL4sEzdAGvRgBVK-g6z4-YGt8uv3Dni6ag) ([발표자료](https://webengineshackfest.org/2024/slides/firefox_wayland_post_mortem_by_martin_stransky.pdf)) - Martin Stransky
   -Firefox는 최근 디스플레이 프로토콜인 [Wayland](https://wayland.freedesktop.org/)를 기본값으로 전환했다.
@@ -29,7 +29,7 @@ Web Engines Hackfest는 2009년 WebkitGTK+ Hackfest라는 이름으로 처음 �
   이 세션은 지원을 달성하는 데 필요한 일련의 이벤트와 변경 사항을 소개한다.
 
 - [Status of the Layer-Based SVG Engine in WebKit](https://youtu.be/WxqJFxiprrU?list=PL4sEzdAGvRgBVK-g6z4-YGt8uv3Dni6ag) ([발표자료](https://webengineshackfest.org/2024/slides/status_of_the_layer-based_svg_engine_in_webkit_by_nikolas_zimmermann.pdf)) - Nikolas Zimmermann
-  - HTML 및 SVG 렌더링 파이프라인을 통합하기 위한 새로운 Webkit 용 SVG 엔진인 [LBE](https://blogs.igalia.com/nzimmermann/posts/2021-10-29-layer-based-svg-engine/)(Layer Based SVG Engine)를 소개한다.
+  - HTML 및 SVG 렌더링 파이프라인을 통합하기 위한 새로운 Webkit 용 SVG 엔진인 [LBSE](https://blogs.igalia.com/nzimmermann/posts/2021-10-29-layer-based-svg-engine/)(Layer Based SVG Engine)를 소개한다.
 
 ## [Config 2024](https://config.figma.com/)
 <img src=https://i.ytimg.com/vi/ZIKZLPWYlAA/maxresdefault.jpg width=500>


### PR DESCRIPTION
매달 유익한 뉴스레터 제공해 주셔서 감사합니다!

오타를 발견해 수정했습니다.
- 정체되왔으나 → 정체되어 왔으나
- LBE → LBSE ([발표자료](https://webengineshackfest.org/2024/slides/status_of_the_layer-based_svg_engine_in_webkit_by_nikolas_zimmermann.pdf) 참고)