### PR TITLE
fix: 2026-01 소식 띄어쓰기 수정

### DIFF
--- a/issues/2026-01.md
+++ b/issues/2026-01.md
@@ -160,7 +160,7 @@ State of HTML 2025는 현대 웹 플랫폼의 HTML 기능과 트렌드를 조사
 
 올해는 개발자들이 자유롭게 작성한 pain point 답변들을 분석하는 데 집중했고, 카테고리별로 분류된 데이터와 응답자의 원본 답변을 검색하고 탐색할 수 있는 기능을 제공한다. 주요 통계로는 Lazy loading이 Newly Available 기능 중 70% 사용률로 가장 높은 채택률을 기록했으며, Content-Security Policy는 전년 대비 10%의 가장 큰 사용률 증가를 보였다. 설문 결과는 Usage, Awareness, Interest, Satisfaction, Appreciation, Positivity 등 6가지 주요 지표로 분석되어 시간에 따른 트렌드를 확인할 수 있다.
 
-HTML의 최신 기능 채택률, 개발자 경험, 그리고 웹 표준의 발전 방향을 이해하는 데 도움이된다.
+HTML의 최신 기능 채택률, 개발자 경험, 그리고 웹 표준의 발전 방향을 이해하는 데 도움이 된다.
 
 # 🕹 튜토리얼
 


### PR DESCRIPTION
안녕하세요.
26년 01월 소식 `State of HTML 2025` 섹션의 마지막 문장에서 발견된 띄어쓰기를 수정했습니다.

- `도움이된다` → `도움이 된다`