### PR TITLE
fix: 2026-06 피그마 MCP 링크 수정

### DIFF
--- a/issues/2026-06.md
+++ b/issues/2026-06.md
@@ -112,7 +112,7 @@ UX 전문가 [Jakob Nielsen](https://en.wikipedia.org/wiki/Jakob_Nielsen_(usabil
 
 <img src="https://cn-geo1.uber.com/image-proc/resize/udam/format=auto/quality=0/width=2160/srcb64=aHR0cHM6Ly90Yi1zdGF0aWMudWJlci5jb20vcHJvZC91ZGFtLWFzc2V0cy85MDczZDljMi05NzQ2LTU1NTUtOWZlOS03NzhiYWI2Njk5NDYucG5n" width="500">
 
-Uber 디자인 시스템 팀이 AI 에이전트를 활용해 수백 개 컴포넌트의 디자인 스펙 문서화를 자동화한 과정을 소개한 글이다. 기존에는 접근성·스펙 문서 작성에 수 주가 걸렸으나, **uSpec** 시스템 도입 후 전체 스크린 리더 스펙을 2분 이내에 생성할 수 있게 됐다. uSpec은 Cursor IDE의 AI 에이전트, [Figma Console MCP](https://www.figma.com/blog/introducing-figmas-model-context-protocol-server/)를 통한 로컬 연결, 도메인 특화 에이전트 스킬을 조합한 구조로, 전체 파이프라인이 로컬에서 실행되어 독점 설계 데이터가 외부로 전송되지 않는다.
+Uber 디자인 시스템 팀이 AI 에이전트를 활용해 수백 개 컴포넌트의 디자인 스펙 문서화를 자동화한 과정을 소개한 글이다. 기존에는 접근성·스펙 문서 작성에 수 주가 걸렸으나, **uSpec** 시스템 도입 후 전체 스크린 리더 스펙을 2분 이내에 생성할 수 있게 됐다. uSpec은 Cursor IDE의 AI 에이전트, [Figma Console MCP](https://www.figma.com/https://www.figma.com/blog/introducing-figma-mcp-server/)를 통한 로컬 연결, 도메인 특화 에이전트 스킬을 조합한 구조로, 전체 파이프라인이 로컬에서 실행되어 독점 설계 데이터가 외부로 전송되지 않는다.
 
 Figma에서 실제 토큰명과 변수값을 직접 읽어오고 구조화된 템플릿으로 일관성 있는 문서를 생성하며, 단일 프롬프트로 7개 구현 스택을 대상으로 한 다중 플랫폼 문서를 생성한다. 프로젝트는 오픈소스로 공개되어 다른 디자인 시스템 팀도 활용할 수 있다.
 

--- a/issues/2026-06.md
+++ b/issues/2026-06.md
@@ -112,7 +112,7 @@ UX 전문가 [Jakob Nielsen](https://en.wikipedia.org/wiki/Jakob_Nielsen_(usabil
 
 <img src="https://cn-geo1.uber.com/image-proc/resize/udam/format=auto/quality=0/width=2160/srcb64=aHR0cHM6Ly90Yi1zdGF0aWMudWJlci5jb20vcHJvZC91ZGFtLWFzc2V0cy85MDczZDljMi05NzQ2LTU1NTUtOWZlOS03NzhiYWI2Njk5NDYucG5n" width="500">
 
-Uber 디자인 시스템 팀이 AI 에이전트를 활용해 수백 개 컴포넌트의 디자인 스펙 문서화를 자동화한 과정을 소개한 글이다. 기존에는 접근성·스펙 문서 작성에 수 주가 걸렸으나, **uSpec** 시스템 도입 후 전체 스크린 리더 스펙을 2분 이내에 생성할 수 있게 됐다. uSpec은 Cursor IDE의 AI 에이전트, [Figma Console MCP](https://www.figma.com/https://www.figma.com/blog/introducing-figma-mcp-server/)를 통한 로컬 연결, 도메인 특화 에이전트 스킬을 조합한 구조로, 전체 파이프라인이 로컬에서 실행되어 독점 설계 데이터가 외부로 전송되지 않는다.
+Uber 디자인 시스템 팀이 AI 에이전트를 활용해 수백 개 컴포넌트의 디자인 스펙 문서화를 자동화한 과정을 소개한 글이다. 기존에는 접근성·스펙 문서 작성에 수 주가 걸렸으나, **uSpec** 시스템 도입 후 전체 스크린 리더 스펙을 2분 이내에 생성할 수 있게 됐다. uSpec은 Cursor IDE의 AI 에이전트, [Figma Console MCP](https://www.figma.com/blog/introducing-figma-mcp-server/)를 통한 로컬 연결, 도메인 특화 에이전트 스킬을 조합한 구조로, 전체 파이프라인이 로컬에서 실행되어 독점 설계 데이터가 외부로 전송되지 않는다.
 
 Figma에서 실제 토큰명과 변수값을 직접 읽어오고 구조화된 템플릿으로 일관성 있는 문서를 생성하며, 단일 프롬프트로 7개 구현 스택을 대상으로 한 다중 플랫폼 문서를 생성한다. 프로젝트는 오픈소스로 공개되어 다른 디자인 시스템 팀도 활용할 수 있다.
 


### PR DESCRIPTION
글 읽다가 Figma MCP 블로그 링크가 Not found라 올바른 링크로 수정합니다.